### PR TITLE
Add OpenAPI tool loading

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,8 @@ setup(
         'pydantic>=2.6.4',
         'pandas>=2.0.0',
         'tabulate>=0.9.0',
+        'pyyaml>=6.0',
+        'requests>=2.0',
     ],
     packages=find_packages(),
     python_requires='>=3.6',

--- a/tests/test_openapi_tools.py
+++ b/tests/test_openapi_tools.py
@@ -1,0 +1,62 @@
+from unittest.mock import patch, Mock
+
+from vaul import Toolkit, tool_call
+
+OPENAPI_SPEC = """
+openapi: 3.0.0
+info:
+  title: Echo API
+  version: 1.0.0
+servers:
+  - url: http://example.com
+paths:
+  /echo:
+    post:
+      operationId: echo
+      summary: Echo message
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+              required:
+                - message
+      responses:
+        '200':
+          description: ok
+"""
+
+def test_add_openapi_tools_and_run():
+    toolkit = Toolkit()
+    toolkit.add_openapi(OPENAPI_SPEC)
+    assert "echo" in toolkit.tool_names
+    tool = toolkit.get_tool("echo")
+    assert tool is not None
+    assert toolkit._tools_df.loc[0, "source"] == "openapi"
+    schema = tool.tool_call_schema
+    assert schema["name"] == "echo"
+    assert "message" in schema["parameters"]["properties"]
+
+    with patch("vaul.openapi.requests.request") as mock_request:
+        mock_resp = Mock()
+        mock_resp.json.return_value = {"echo": "hi"}
+        mock_request.return_value = mock_resp
+        result = toolkit.run_tool("echo", {"message": "hi"})
+        mock_request.assert_called_once()
+        assert result["echo"] == "hi"
+
+
+def test_local_tool_source_column():
+    toolkit = Toolkit()
+
+    @tool_call
+    def add(a: int, b: int) -> int:
+        """Add numbers"""
+        return a + b
+
+    toolkit.add(add)
+    assert toolkit._tools_df.loc[0, "source"] == "local"

--- a/vaul/__init__.py
+++ b/vaul/__init__.py
@@ -1,4 +1,5 @@
 from .decorators import tool_call, StructuredOutput
 from .registry import Toolkit
+from .openapi import tools_from_openapi
 
-__all__ = ["tool_call", "StructuredOutput", "Toolkit"]
+__all__ = ["tool_call", "StructuredOutput", "Toolkit", "tools_from_openapi"]

--- a/vaul/openapi.py
+++ b/vaul/openapi.py
@@ -1,0 +1,101 @@
+import re
+from typing import Any, Dict, List, Union
+
+import requests
+import yaml
+
+from .decorators import tool_call, ToolCall
+from .utils import remove_keys_recursively
+
+
+def _create_api_tool(name: str, method: str, url: str, description: str, schema: Dict[str, Any]) -> ToolCall:
+    """Create a ToolCall that performs an HTTP request."""
+
+    def api_function(**kwargs):
+        local_url = url
+        for param in re.findall(r"{(.*?)}", url):
+            if param in kwargs:
+                local_url = local_url.replace(f"{{{param}}}", str(kwargs.pop(param)))
+        if method.upper() == "GET":
+            response = requests.request(method, local_url, params=kwargs)
+        else:
+            response = requests.request(method, local_url, json=kwargs)
+        try:
+            return response.json()
+        except Exception:
+            return response.text
+
+    api_function.__name__ = name
+    api_function.__doc__ = description or ""
+
+    tool = tool_call(api_function)
+    tool.tool_call_schema = schema
+    return tool
+
+
+def tools_from_openapi(spec: Union[str, Dict[str, Any]]) -> List[ToolCall]:
+    """Convert an OpenAPI specification to ToolCall instances."""
+    if isinstance(spec, dict):
+        spec_dict = spec
+    else:
+        if spec.strip().startswith("http://") or spec.strip().startswith("https://"):
+            text = requests.get(spec).text
+        else:
+            text = spec
+        spec_dict = yaml.safe_load(text)
+
+    base_url = ""
+    servers = spec_dict.get("servers")
+    if servers and isinstance(servers, list) and servers:
+        base_url = servers[0].get("url", "")
+
+    tools: List[ToolCall] = []
+
+    for path, path_item in spec_dict.get("paths", {}).items():
+        for method, operation in path_item.items():
+            if method.lower() not in {"get", "post", "put", "delete", "patch"}:
+                continue
+
+            name = operation.get("operationId") or f"{method}_{path.strip('/').replace('/', '_')}"
+            description = operation.get("summary") or operation.get("description", "")
+
+            properties: Dict[str, Any] = {}
+            required: List[str] = []
+            params = []
+            params.extend(path_item.get("parameters", []))
+            params.extend(operation.get("parameters", []))
+
+            for param in params:
+                if "$ref" in param:
+                    continue
+                schema = param.get("schema", {"type": "string"})
+                properties[param["name"]] = schema
+                if param.get("required"):
+                    required.append(param["name"])
+
+            if "requestBody" in operation:
+                content = operation["requestBody"].get("content", {})
+                if "application/json" in content:
+                    body_schema = content["application/json"].get("schema", {})
+                    if body_schema.get("type") == "object":
+                        properties.update(body_schema.get("properties", {}))
+                        required.extend(body_schema.get("required", []))
+                    elif body_schema:
+                        properties["data"] = body_schema
+                        if operation["requestBody"].get("required"):
+                            required.append("data")
+
+            param_schema = {
+                "type": "object",
+                "properties": properties,
+                "required": sorted(set(required)),
+            }
+            param_schema = remove_keys_recursively(param_schema, "title")
+            param_schema = remove_keys_recursively(param_schema, "additionalProperties")
+
+            schema = {"name": name, "description": description, "parameters": param_schema}
+
+            tool = _create_api_tool(name, method.upper(), base_url + path, description, schema)
+            tools.append(tool)
+
+    return tools

--- a/vaul/registry.py
+++ b/vaul/registry.py
@@ -4,6 +4,7 @@ import pandas as pd
 from tabulate import tabulate
 
 from vaul.decorators import ToolCall
+from vaul.openapi import tools_from_openapi
 
 
 class Toolkit:
@@ -40,9 +41,9 @@ class Toolkit:
         """
         Initialize a new Toolkit with an empty registry of tools.
         """
-        self._tools_df = pd.DataFrame(columns=["name", "tool"])
+        self._tools_df = pd.DataFrame(columns=["name", "tool", "source"])
 
-    def add(self, tool: ToolCall) -> None:
+    def add(self, tool: ToolCall, source: str = "local") -> None:
         """
         Register a tool call instance in the toolkit.
 
@@ -72,10 +73,10 @@ class Toolkit:
         if not self._tools_df[self._tools_df["name"] == tool_name].empty:
             raise ValueError(f"A tool with name '{tool_name}' is already registered")
 
-        new_row = pd.DataFrame({"name": [tool_name], "tool": [tool]})
+        new_row = pd.DataFrame({"name": [tool_name], "tool": [tool], "source": [source]})
         self._tools_df = pd.concat([self._tools_df, new_row], ignore_index=True)
 
-    def add_tools(self, *tools: ToolCall) -> None:
+    def add_tools(self, *tools: ToolCall, source: str = "local") -> None:
         """
         Register multiple tool call instances in the toolkit at once.
 
@@ -107,7 +108,12 @@ class Toolkit:
             ```
         """
         for tool in tools:
-            self.add(tool)
+            self.add(tool, source=source)
+
+    def add_openapi(self, spec: Any) -> None:
+        """Add tools from an OpenAPI specification string or URL."""
+        for tool in tools_from_openapi(spec):
+            self.add(tool, source="openapi")
 
     def remove(self, name: str) -> bool:
         """
@@ -296,7 +302,7 @@ class Toolkit:
             print(len(toolkit))  # Output: 0
             ```
         """
-        self._tools_df = pd.DataFrame(columns=["name", "tool"])
+        self._tools_df = pd.DataFrame(columns=["name", "tool", "source"])
 
     def has_tools(self) -> bool:
         """


### PR DESCRIPTION
## Summary
- add new `tools_from_openapi` helper
- extend `Toolkit` with support for OpenAPI specs and track source of tools
- export `tools_from_openapi`
- include requests/pyyaml dependencies
- tests for loading OpenAPI tools

## Testing
- `pytest -q -o addopts=''` *(fails: ImportError: cannot import name 'TypeAdapter' from 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68473dfa37f0832fa623051647dcbd16