### PR TITLE
Add MCP client session integration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=45", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [tool.pytest.ini_options]
 addopts = "--cov=vaul --cov-report=term-missing --cov-fail-under=85"
 testpaths = ["tests"]

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@ setup(
         'tabulate>=0.9.0',
         'pyyaml>=6.0',
         'requests>=2.0',
+        'mcp>=1.0.0',
+        'nest-asyncio>=1.5.0',
     ],
     packages=find_packages(),
     python_requires='>=3.6',

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,5 @@ setup(
         'nest-asyncio>=1.5.0',
     ],
     packages=find_packages(),
-    python_requires='>=3.6',
+    python_requires='>=3.10',
 )

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1,0 +1,34 @@
+from vaul import Toolkit
+
+
+class FakeSession:
+    async def list_tools(self):
+        class Tool:
+            name = "echo"
+            description = "Echo message"
+            inputSchema = {
+                "type": "object",
+                "properties": {"message": {"type": "string"}},
+                "required": ["message"],
+            }
+
+        class Response:
+            tools = [Tool()]
+
+        return Response()
+
+    async def call_tool(self, name, arguments):
+        return {name: arguments.get("message")}
+
+
+def test_add_mcp_tools_and_run():
+    toolkit = Toolkit()
+    session = FakeSession()
+
+    toolkit.add_mcp(session)
+
+    assert "echo" in toolkit.tool_names
+    assert toolkit._tools_df.loc[0, "source"] == "mcp"
+
+    result = toolkit.run_tool("echo", {"message": "hi"})
+    assert result["echo"] == "hi"

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1,7 +1,22 @@
+"""Test suite for MCP tools integration."""
+
+import pytest
+from unittest.mock import Mock, patch
+
 from vaul import Toolkit
+from vaul.mcp import (
+    _extract_tool_metadata,
+    _extract_result_content,
+    _parse_tools_response,
+    tools_from_mcp,
+    tools_from_mcp_url,
+    tools_from_mcp_stdio,
+)
 
 
 class FakeSession:
+    """Fake MCP session for testing."""
+    
     async def list_tools(self):
         class Tool:
             name = "echo"
@@ -21,14 +36,231 @@ class FakeSession:
         return {name: arguments.get("message")}
 
 
-def test_add_mcp_tools_and_run():
-    toolkit = Toolkit()
-    session = FakeSession()
+class TestMCPIntegration:
+    """Test MCP integration with Toolkit."""
+    
+    def test_add_mcp_tools_and_run(self):
+        """Test adding MCP tools from session and running them."""
+        toolkit = Toolkit()
+        session = FakeSession()
 
-    toolkit.add_mcp(session)
+        toolkit.add_mcp(session)
 
-    assert "echo" in toolkit.tool_names
-    assert toolkit._tools_df.loc[0, "source"] == "mcp"
+        assert "echo" in toolkit.tool_names
+        assert toolkit._tools_df.loc[0, "source"] == "mcp"
 
-    result = toolkit.run_tool("echo", {"message": "hi"})
-    assert result["echo"] == "hi"
+        result = toolkit.run_tool("echo", {"message": "hi"})
+        assert result["echo"] == "hi"
+    
+    def test_add_mcp_from_url(self):
+        """Test adding MCP tools from URL."""
+        toolkit = Toolkit()
+        
+        with patch('vaul.mcp.tools_from_mcp_url') as mock_tools:
+            # Create a proper ToolCall mock
+            from vaul.decorators import ToolCall
+            mock_tool = Mock(spec=ToolCall)
+            mock_tool.func = Mock()
+            mock_tool.func.__name__ = "url_tool"
+            mock_tools.return_value = [mock_tool]
+            
+            toolkit.add_mcp("https://example.com/mcp")
+            
+            assert len(toolkit) == 1
+            mock_tools.assert_called_once_with("https://example.com/mcp")
+    
+    def test_add_mcp_from_stdio(self):
+        """Test adding MCP tools from stdio configuration."""
+        toolkit = Toolkit()
+        
+        with patch('vaul.mcp.tools_from_mcp_stdio') as mock_tools:
+            # Create a proper ToolCall mock
+            from vaul.decorators import ToolCall
+            mock_tool = Mock(spec=ToolCall)
+            mock_tool.func = Mock()
+            mock_tool.func.__name__ = "stdio_tool"
+            mock_tools.return_value = [mock_tool]
+            
+            toolkit.add_mcp({
+                "command": "python",
+                "args": ["server.py"],
+                "env": {"KEY": "value"}
+            })
+            
+            assert len(toolkit) == 1
+            mock_tools.assert_called_once_with(command="python", args=["server.py"], env={"KEY": "value"})
+    
+    def test_add_mcp_invalid_stdio_config(self):
+        """Test error handling for invalid stdio configuration."""
+        toolkit = Toolkit()
+        
+        # Missing command
+        with pytest.raises(ValueError, match="must include 'command'"):
+            toolkit.add_mcp({})
+        
+        # Invalid command type
+        with pytest.raises(TypeError, match="'command' must be a string"):
+            toolkit.add_mcp({"command": 123})
+        
+        # Invalid args type
+        with pytest.raises(TypeError, match="'args' must be a list"):
+            toolkit.add_mcp({"command": "python", "args": "not_a_list"})
+        
+        # Invalid env type
+        with pytest.raises(TypeError, match="'env' must be a dictionary"):
+            toolkit.add_mcp({"command": "python", "env": "not_a_dict"})
+    
+    def test_add_mcp_unsupported_type(self):
+        """Test error handling for unsupported MCP source types."""
+        toolkit = Toolkit()
+        
+        with pytest.raises(TypeError, match="Unsupported MCP source type"):
+            toolkit.add_mcp(123)
+
+
+class TestMCPHelpers:
+    """Test MCP helper functions."""
+    
+    def test_extract_tool_metadata_variations(self):
+        """Test extracting metadata from various formats."""
+        # Object with attributes
+        tool1 = Mock()
+        tool1.name = "tool1"
+        tool1.description = "Description 1"
+        tool1.inputSchema = {"type": "object"}
+        
+        name, desc, schema = _extract_tool_metadata(tool1)
+        assert name == "tool1"
+        assert desc == "Description 1"
+        assert schema == {"type": "object"}
+        
+        # Dictionary format
+        tool2 = {
+            "name": "tool2",
+            "description": "Description 2",
+            "parameters": {"type": "string"}
+        }
+        
+        name, desc, schema = _extract_tool_metadata(tool2)
+        assert name == "tool2"
+        assert desc == "Description 2"
+        assert schema == {"type": "string"}
+        
+        # Mixed format with getattr fallback
+        tool3 = Mock()
+        tool3.name = None
+        tool3.get = lambda x, default=None: {"name": "tool3"}.get(x, default)
+        
+        name, desc, schema = _extract_tool_metadata(tool3)
+        assert name == "tool3"
+    
+    def test_extract_result_content_variations(self):
+        """Test extracting content from various result formats."""
+        # Content list with text
+        result1 = Mock()
+        result1.content = [Mock(text="Hello", data=None)]
+        assert _extract_result_content(result1) == "Hello"
+        
+        # Content list with data
+        result2 = Mock()
+        result2.content = [Mock(text=None, data={"key": "value"})]
+        assert _extract_result_content(result2) == {"key": "value"}
+        
+        # Direct content string
+        result3 = Mock()
+        result3.content = "Direct content"
+        assert _extract_result_content(result3) == "Direct content"
+        
+        # Result attribute
+        result4 = Mock(spec=['result'])
+        result4.result = "Result value"
+        assert _extract_result_content(result4) == "Result value"
+        
+        # Plain value
+        assert _extract_result_content("plain") == "plain"
+    
+    def test_parse_tools_response_variations(self):
+        """Test parsing tools from various response formats."""
+        # Object with tools attribute
+        resp1 = Mock()
+        resp1.tools = ["tool1", "tool2"]
+        assert _parse_tools_response(resp1) == ["tool1", "tool2"]
+        
+        # Dictionary with tools key
+        resp2 = {"tools": ["tool3"]}
+        assert _parse_tools_response(resp2) == ["tool3"]
+        
+        # Direct list
+        resp3 = ["tool4", "tool5"]
+        assert _parse_tools_response(resp3) == ["tool4", "tool5"]
+        
+        # Invalid formats
+        assert _parse_tools_response(None) == []
+        assert _parse_tools_response("invalid") == []
+
+
+class TestMCPToolsCreation:
+    """Test MCP tool creation functions."""
+    
+    @patch('vaul.mcp._run_async')
+    def test_tools_from_mcp_session(self, mock_run_async):
+        """Test creating tools from an MCP session."""
+        session = Mock()
+        mock_tools = [Mock(), Mock()]
+        mock_run_async.return_value = mock_tools
+        
+        result = tools_from_mcp(session)
+        
+        assert result == mock_tools
+        assert mock_run_async.called
+    
+    @patch('vaul.mcp._run_async')
+    @patch('vaul.mcp.sse_client')
+    def test_tools_from_mcp_url_with_headers(self, mock_sse_client, mock_run_async):
+        """Test creating tools from URL with headers."""
+        mock_tools = [Mock()]
+        mock_run_async.return_value = mock_tools
+        
+        result = tools_from_mcp_url("https://example.com", {"Auth": "Bearer token"})
+        
+        assert result == mock_tools
+        assert mock_run_async.called
+    
+    @patch('vaul.mcp._run_async')
+    @patch('vaul.mcp.stdio_client')
+    def test_tools_from_mcp_stdio_with_env(self, mock_stdio_client, mock_run_async):
+        """Test creating tools from stdio with environment variables."""
+        mock_tools = [Mock()]
+        mock_run_async.return_value = mock_tools
+        
+        result = tools_from_mcp_stdio("node", ["server.js"], {"NODE_ENV": "test"})
+        
+        assert result == mock_tools
+        assert mock_run_async.called
+
+
+class TestMCPResultExtraction:
+    """Test result extraction from MCP responses."""
+    
+    def test_complex_content_extraction(self):
+        """Test extracting content from complex nested structures."""
+        # Nested content with multiple items
+        result = Mock()
+        item1 = Mock()
+        item1.text = None
+        item1.data = None
+        item2 = Mock()
+        item2.text = "Second item"
+        result.content = [item1, item2]
+        
+        # Should extract from first item even if it needs string conversion
+        extracted = _extract_result_content(result)
+        assert isinstance(extracted, str)
+    
+    def test_empty_content_list(self):
+        """Test handling empty content list."""
+        result = Mock()
+        result.content = []
+        
+        extracted = _extract_result_content(result)
+        assert extracted == "[]"  # String representation of empty list

--- a/tests/test_openapi_tools.py
+++ b/tests/test_openapi_tools.py
@@ -28,6 +28,19 @@ paths:
       responses:
         '200':
           description: ok
+  /users/{userId}:
+    get:
+      operationId: getUser
+      summary: Get user by ID
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ok
 """
 
 def test_add_openapi_tools_and_run():
@@ -60,3 +73,123 @@ def test_local_tool_source_column():
 
     toolkit.add(add)
     assert toolkit._tools_df.loc[0, "source"] == "local"
+
+
+def test_openapi_with_headers():
+    """Test adding OpenAPI tools with custom headers."""
+    toolkit = Toolkit()
+    headers = {"X-API-Key": "test-key", "Authorization": "Bearer token"}
+    
+    toolkit.add_openapi(OPENAPI_SPEC, headers=headers)
+    assert "echo" in toolkit.tool_names
+    
+    # Test that headers are passed to requests
+    with patch("vaul.openapi.requests.request") as mock_request:
+        mock_resp = Mock()
+        mock_resp.json.return_value = {"result": "ok"}
+        mock_request.return_value = mock_resp
+        
+        toolkit.run_tool("echo", {"message": "test"})
+        
+        # Verify headers were included in the request
+        call_args = mock_request.call_args
+        assert call_args.kwargs["headers"] == headers
+
+
+def test_openapi_with_params():
+    """Test adding OpenAPI tools with query parameters."""
+    toolkit = Toolkit()
+    params = {"api_key": "12345", "version": "v2"}
+    
+    toolkit.add_openapi(OPENAPI_SPEC, params=params)
+    
+    with patch("vaul.openapi.requests.request") as mock_request:
+        mock_resp = Mock()
+        mock_resp.json.return_value = {"result": "ok"}
+        mock_request.return_value = mock_resp
+        
+        # Test GET request with params
+        toolkit.run_tool("getUser", {"userId": "123"})
+        
+        call_args = mock_request.call_args
+        # For GET requests, params should be merged
+        assert call_args.kwargs["params"] == params
+
+
+def test_openapi_with_session():
+    """Test adding OpenAPI tools with a custom session."""
+    toolkit = Toolkit()
+    
+    # Create a mock session
+    mock_session = Mock()
+    mock_session.request.return_value.json.return_value = {"result": "ok"}
+    
+    toolkit.add_openapi(OPENAPI_SPEC, session=mock_session)
+    
+    # Run a tool and verify session was used
+    toolkit.run_tool("echo", {"message": "test"})
+    
+    # Verify session.request was called instead of requests.request
+    mock_session.request.assert_called_once()
+    call_args = mock_session.request.call_args
+    assert call_args.kwargs["method"] == "POST"
+    assert call_args.kwargs["json"] == {"message": "test"}
+
+
+def test_openapi_operation_filtering():
+    """Test filtering operations by operationId."""
+    toolkit = Toolkit()
+    
+    # Add only specific operations
+    toolkit.add_openapi(OPENAPI_SPEC, operation_ids=["echo"])
+    
+    # Should only have the echo operation
+    assert "echo" in toolkit.tool_names
+    assert "getUser" not in toolkit.tool_names
+    assert len(toolkit.tool_names) == 1
+    
+    # Test with multiple operations
+    toolkit2 = Toolkit()
+    toolkit2.add_openapi(OPENAPI_SPEC, operation_ids=["echo", "getUser"])
+    assert len(toolkit2.tool_names) == 2
+    
+    # Test with non-existent operation
+    toolkit3 = Toolkit()
+    toolkit3.add_openapi(OPENAPI_SPEC, operation_ids=["nonExistent"])
+    assert len(toolkit3.tool_names) == 0
+
+
+def test_openapi_file_loading():
+    """Test loading OpenAPI spec from file."""
+    import tempfile
+    import os
+    
+    # Create a temporary file with the spec
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+        f.write(OPENAPI_SPEC)
+        temp_file = f.name
+    
+    try:
+        toolkit = Toolkit()
+        toolkit.add_openapi(temp_file)
+        assert "echo" in toolkit.tool_names
+        assert "getUser" in toolkit.tool_names
+    finally:
+        os.unlink(temp_file)
+
+
+def test_openapi_path_parameter_replacement():
+    """Test that path parameters are correctly replaced."""
+    toolkit = Toolkit()
+    toolkit.add_openapi(OPENAPI_SPEC)
+    
+    with patch("vaul.openapi.requests.request") as mock_request:
+        mock_resp = Mock()
+        mock_resp.json.return_value = {"id": "123", "name": "John"}
+        mock_request.return_value = mock_resp
+        
+        toolkit.run_tool("getUser", {"userId": "123"})
+        
+        # Verify the URL had the parameter replaced
+        call_args = mock_request.call_args
+        assert call_args.kwargs["url"] == "http://example.com/users/123"

--- a/vaul/__init__.py
+++ b/vaul/__init__.py
@@ -1,5 +1,12 @@
 from .decorators import tool_call, StructuredOutput
 from .registry import Toolkit
 from .openapi import tools_from_openapi
+from .mcp import tools_from_mcp
 
-__all__ = ["tool_call", "StructuredOutput", "Toolkit", "tools_from_openapi"]
+__all__ = [
+    "tool_call",
+    "StructuredOutput",
+    "Toolkit",
+    "tools_from_openapi",
+    "tools_from_mcp",
+]

--- a/vaul/__init__.py
+++ b/vaul/__init__.py
@@ -1,7 +1,7 @@
 from .decorators import tool_call, StructuredOutput
 from .registry import Toolkit
 from .openapi import tools_from_openapi
-from .mcp import tools_from_mcp
+from .mcp import tools_from_mcp, tools_from_mcp_url, tools_from_mcp_stdio
 
 __all__ = [
     "tool_call",
@@ -9,4 +9,6 @@ __all__ = [
     "Toolkit",
     "tools_from_openapi",
     "tools_from_mcp",
+    "tools_from_mcp_url",
+    "tools_from_mcp_stdio",
 ]

--- a/vaul/mcp.py
+++ b/vaul/mcp.py
@@ -1,0 +1,58 @@
+"""Utilities for working with MCP servers."""
+
+from typing import Any, Dict, List
+
+import asyncio
+
+from mcp import ClientSession
+
+from .decorators import tool_call, ToolCall
+
+
+def _run_async(coro: Any) -> Any:
+    """Run an async coroutine synchronously in a new event loop."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _create_mcp_tool(session: ClientSession, tool: Any) -> ToolCall:
+    """Create a ``ToolCall`` wrapper around an MCP tool."""
+    name = getattr(tool, "name")
+    description = getattr(tool, "description", "") or ""
+    schema = (
+        getattr(tool, "input_schema", None)
+        or getattr(tool, "inputSchema", None)
+        or getattr(tool, "parameters", None)
+        or {}
+    )
+
+    async def _async_call(**kwargs):
+        return await session.call_tool(name=name, arguments=kwargs)
+
+    def mcp_function(**kwargs):
+        return _run_async(_async_call(**kwargs))
+
+    mcp_function.__name__ = name
+    mcp_function.__doc__ = description
+
+    tool_call_wrapper = tool_call(mcp_function)
+    tool_call_wrapper.tool_call_schema = {
+        "name": name,
+        "description": description,
+        "parameters": schema,
+    }
+    return tool_call_wrapper
+
+
+def tools_from_mcp(session: ClientSession) -> List[ToolCall]:
+    """Load tools from an MCP ``ClientSession``."""
+    response = _run_async(session.list_tools())
+    tools_data = getattr(response, "tools", response)
+
+    tools: List[ToolCall] = []
+    for item in tools_data:
+        tools.append(_create_mcp_tool(session, item))
+    return tools

--- a/vaul/mcp.py
+++ b/vaul/mcp.py
@@ -1,58 +1,245 @@
 """Utilities for working with MCP servers."""
 
-from typing import Any, Dict, List
-
+from typing import Any, List, Dict, Optional, Callable
 import asyncio
+import concurrent.futures
+import logging
 
-from mcp import ClientSession
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+from mcp.client.sse import sse_client
 
 from .decorators import tool_call, ToolCall
 
+logger = logging.getLogger(__name__)
+
 
 def _run_async(coro: Any) -> Any:
-    """Run an async coroutine synchronously in a new event loop."""
-    loop = asyncio.new_event_loop()
+    """Run an async coroutine synchronously, handling nested event loops."""
     try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # No event loop running - create and use a new one
+        return asyncio.run(coro)
+    
+    # Event loop already running - handle nested case
+    try:
+        import nest_asyncio
+        nest_asyncio.apply()
         return loop.run_until_complete(coro)
-    finally:
-        loop.close()
+    except ImportError:
+        # Fall back to thread-based execution
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            future = executor.submit(asyncio.run, coro)
+            return future.result()
 
 
-def _create_mcp_tool(session: ClientSession, tool: Any) -> ToolCall:
-    """Create a ``ToolCall`` wrapper around an MCP tool."""
-    name = getattr(tool, "name")
-    description = getattr(tool, "description", "") or ""
-    schema = (
-        getattr(tool, "input_schema", None)
-        or getattr(tool, "inputSchema", None)
-        or getattr(tool, "parameters", None)
-        or {}
-    )
+def _extract_tool_metadata(tool: Any) -> tuple[str, str, dict]:
+    """Extract name, description, and schema from various tool formats."""
+    # Get name (required)
+    name = getattr(tool, "name", None) or tool.get("name", "")
+    if not name:
+        raise ValueError("Tool must have a name")
+    
+    # Get description (optional)
+    description = getattr(tool, "description", "") or tool.get("description", "")
+    
+    # Get schema (optional) - try common attribute names
+    schema = {}
+    for attr in ["inputSchema", "input_schema", "parameters"]:
+        schema = getattr(tool, attr, None) or tool.get(attr, {})
+        if schema:
+            break
+    
+    return name, description, schema
 
-    async def _async_call(**kwargs):
-        return await session.call_tool(name=name, arguments=kwargs)
 
-    def mcp_function(**kwargs):
-        return _run_async(_async_call(**kwargs))
+def _extract_result_content(result: Any) -> Any:
+    """Extract content from various MCP result formats."""
+    # Check for 'content' attribute
+    if hasattr(result, 'content'):
+        content = result.content
+        
+        # Handle list of content items
+        if isinstance(content, list) and content:
+            item = content[0]
+            # Try to extract text or data from the item
+            return getattr(item, 'text', None) or getattr(item, 'data', None) or str(item)
+        
+        return str(content)
+    
+    # Check for 'result' attribute
+    if hasattr(result, 'result'):
+        return result.result
+    
+    # Return as-is if no special handling needed
+    return result
 
-    mcp_function.__name__ = name
-    mcp_function.__doc__ = description
 
-    tool_call_wrapper = tool_call(mcp_function)
-    tool_call_wrapper.tool_call_schema = {
+def _parse_tools_response(response: Any) -> List[Any]:
+    """Parse tools from various response formats."""
+    # Try different ways to extract tools list
+    if hasattr(response, 'tools'):
+        return response.tools
+    if isinstance(response, dict) and 'tools' in response:
+        return response['tools']
+    if isinstance(response, list):
+        return response
+    
+    return []
+
+
+def _create_tool_wrapper(
+    name: str,
+    description: str,
+    schema: dict,
+    async_call_func: Callable
+) -> ToolCall:
+    """Create a ToolCall wrapper with the given metadata and async call function."""
+    # Create synchronous wrapper
+    def sync_wrapper(**kwargs):
+        return _run_async(async_call_func(**kwargs))
+    
+    # Set function metadata
+    sync_wrapper.__name__ = name
+    sync_wrapper.__doc__ = description
+    
+    # Create and configure the tool
+    tool = tool_call(sync_wrapper)
+    tool.tool_call_schema = {
         "name": name,
         "description": description,
         "parameters": schema,
     }
-    return tool_call_wrapper
+    
+    return tool
 
+
+def _create_tool_from_metadata(
+    tool_metadata: Any,
+    create_async_call: Callable[[str], Callable]
+) -> ToolCall:
+    """Create a tool from metadata and an async call factory."""
+    name, description, schema = _extract_tool_metadata(tool_metadata)
+    async_call = create_async_call(name)
+    return _create_tool_wrapper(name, description, schema, async_call)
+
+async def _load_tools_async(
+    session: ClientSession,
+    create_tool: Callable[[Any], ToolCall]
+) -> List[ToolCall]:
+    """Load tools from an MCP session asynchronously."""
+    response = await session.list_tools()
+    tools_data = _parse_tools_response(response)
+    
+    tools = []
+    for item in tools_data:
+        try:
+            tool = create_tool(item)
+            tools.append(tool)
+        except Exception as e:
+            logger.warning(f"Failed to create tool: {e}")
+    
+    return tools
 
 def tools_from_mcp(session: ClientSession) -> List[ToolCall]:
-    """Load tools from an MCP ``ClientSession``."""
-    response = _run_async(session.list_tools())
-    tools_data = getattr(response, "tools", response)
+    """
+    Load tools from an existing MCP ClientSession.
+    
+    Args:
+        session: An active MCP ClientSession
+        
+    Returns:
+        List of ToolCall objects that can be added to a Toolkit
+    """
+    def create_tool(tool_metadata: Any) -> ToolCall:
+        """Create a tool that uses the existing session."""
+        def create_async_call(name: str):
+            async def call(**kwargs):
+                result = await session.call_tool(name=name, arguments=kwargs)
+                return _extract_result_content(result)
+            return call
+        
+        return _create_tool_from_metadata(tool_metadata, create_async_call)
+    
+    return _run_async(_load_tools_async(session, create_tool))
 
-    tools: List[ToolCall] = []
-    for item in tools_data:
-        tools.append(_create_mcp_tool(session, item))
-    return tools
+
+def tools_from_mcp_url(
+    url: str,
+    headers: Optional[Dict[str, str]] = None
+) -> List[ToolCall]:
+    """
+    Load tools from an MCP server URL (SSE endpoint).
+    
+    Args:
+        url: The SSE endpoint URL
+        headers: Optional HTTP headers
+        
+    Returns:
+        List of ToolCall objects that can be added to a Toolkit
+    """
+    async def load():
+        async with sse_client(url, headers=headers or {}) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                
+                def create_tool(tool_metadata: Any) -> ToolCall:
+                    """Create a tool that uses the SSE session."""
+                    def create_async_call(name: str):
+                        async def call(**kwargs):
+                            result = await session.call_tool(name=name, arguments=kwargs)
+                            return _extract_result_content(result)
+                        return call
+                    
+                    return _create_tool_from_metadata(tool_metadata, create_async_call)
+                
+                return await _load_tools_async(session, create_tool)
+    
+    return _run_async(load())
+
+
+def tools_from_mcp_stdio(
+    command: str,
+    args: Optional[List[str]] = None,
+    env: Optional[Dict[str, str]] = None
+) -> List[ToolCall]:
+    """
+    Load tools from an MCP server via stdio (subprocess).
+    
+    Args:
+        command: The command to run
+        args: Optional command arguments
+        env: Optional environment variables
+        
+    Returns:
+        List of ToolCall objects that can be added to a Toolkit
+    """
+    server_params = StdioServerParameters(
+        command=command,
+        args=args or [],
+        env=env
+    )
+    
+    async def load():
+        async with stdio_client(server_params) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                
+                def create_tool(tool_metadata: Any) -> ToolCall:
+                    """Create a tool that reconnects for each call."""
+                    def create_async_call(name: str):
+                        async def call(**kwargs):
+                            # Reconnect for each call to handle stdio lifecycle
+                            async with stdio_client(server_params) as (r, w):
+                                async with ClientSession(r, w) as sess:
+                                    await sess.initialize()
+                                    result = await sess.call_tool(name=name, arguments=kwargs)
+                                    return _extract_result_content(result)
+                        return call
+                    
+                    return _create_tool_from_metadata(tool_metadata, create_async_call)
+                
+                return await _load_tools_async(session, create_tool)
+    
+    return _run_async(load())

--- a/vaul/openapi.py
+++ b/vaul/openapi.py
@@ -93,7 +93,7 @@ def tools_from_openapi(spec: Union[str, Dict[str, Any]],
             try:
                 with open(spec, 'r') as f:
                     text = f.read()
-            except:
+            except (OSError, IOError):
                 # If not a file, treat as raw YAML/JSON string
                 text = spec
         spec_dict = yaml.safe_load(text)

--- a/vaul/registry.py
+++ b/vaul/registry.py
@@ -115,6 +115,13 @@ class Toolkit:
         for tool in tools_from_openapi(spec):
             self.add(tool, source="openapi")
 
+    def add_mcp(self, session: Any) -> None:
+        """Add tools from an MCP ``ClientSession``."""
+        from vaul.mcp import tools_from_mcp
+
+        for tool in tools_from_mcp(session):
+            self.add(tool, source="mcp")
+
     def remove(self, name: str) -> bool:
         """
         Unregister a tool by name from the toolkit.

--- a/vaul/registry.py
+++ b/vaul/registry.py
@@ -4,7 +4,6 @@ import pandas as pd
 from tabulate import tabulate
 
 from vaul.decorators import ToolCall
-from vaul.openapi import tools_from_openapi
 
 
 class Toolkit:

--- a/vaul/registry.py
+++ b/vaul/registry.py
@@ -110,17 +110,124 @@ class Toolkit:
         for tool in tools:
             self.add(tool, source=source)
 
-    def add_openapi(self, spec: Any) -> None:
-        """Add tools from an OpenAPI specification string or URL."""
-        for tool in tools_from_openapi(spec):
+    def add_openapi(self, spec: Any, headers: Optional[Dict[str, str]] = None, 
+                    params: Optional[Dict[str, str]] = None, 
+                    session: Optional[Any] = None,
+                    operation_ids: Optional[List[str]] = None) -> None:
+        """
+        Add tools from an OpenAPI specification.
+        
+        Args:
+            spec: OpenAPI specification as a URL, file path, dict, or YAML/JSON string
+            headers: Optional headers to include in API requests
+            params: Optional query parameters to include in API requests
+            session: Optional requests.Session for custom authentication
+            operation_ids: Optional list of operation IDs to import (imports all if None)
+            
+        Example:
+            ```python
+            # From URL
+            toolkit.add_openapi("https://api.example.com/openapi.json")
+            
+            # With authentication
+            toolkit.add_openapi(
+                "https://api.example.com/openapi.json",
+                headers={"X-API-Key": "your-key"}
+            )
+            
+            # Filter specific operations
+            toolkit.add_openapi(
+                "https://api.example.com/openapi.json",
+                operation_ids=["getUserById", "createUser"]
+            )
+            ```
+        """
+        from vaul.openapi import tools_from_openapi
+        
+        tools = tools_from_openapi(
+            spec, 
+            headers=headers, 
+            params=params, 
+            session=session,
+            operation_ids=operation_ids
+        )
+        
+        for tool in tools:
             self.add(tool, source="openapi")
 
-    def add_mcp(self, session: Any) -> None:
-        """Add tools from an MCP ``ClientSession``."""
-        from vaul.mcp import tools_from_mcp
-
-        for tool in tools_from_mcp(session):
+    def add_mcp(self, mcp_source: Any, **kwargs) -> None:
+        """
+        Add tools from an MCP server.
+        
+        Args:
+            mcp_source: Can be one of:
+                - ClientSession: An existing MCP ClientSession
+                - str: URL for SSE-based MCP server (e.g., "https://mcp.example.com/sse")
+                - dict: Configuration for stdio-based MCP server with keys:
+                    - command: Command to run (required)
+                    - args: List of arguments (optional)
+                    - env: Environment variables (optional)
+            **kwargs: Additional arguments passed to the MCP loader functions
+        
+        Example:
+            ```python
+            toolkit = Toolkit()
+            
+            # Add from URL-based MCP server
+            toolkit.add_mcp("https://actions.zapier.com/mcp/sse")
+            
+            # Add from stdio-based MCP server
+            toolkit.add_mcp({
+                "command": "python3",
+                "args": ["./mcp_server.py"]
+            })
+            
+            # Add from existing session
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                toolkit.add_mcp(session)
+            ```
+        """
+        from vaul.mcp import tools_from_mcp, tools_from_mcp_url, tools_from_mcp_stdio
+        
+        # Determine the type of MCP source and load tools accordingly
+        if hasattr(mcp_source, 'call_tool'):
+            # It's a ClientSession
+            tools = tools_from_mcp(mcp_source)
+        elif isinstance(mcp_source, str):
+            # It's a URL
+            tools = tools_from_mcp_url(mcp_source, **kwargs)
+        elif isinstance(mcp_source, dict):
+            # It's a stdio configuration
+            self._validate_stdio_config(mcp_source)
+            tools = tools_from_mcp_stdio(
+                command=mcp_source['command'],
+                args=mcp_source.get('args', []),
+                env=mcp_source.get('env')
+            )
+        else:
+            raise TypeError(
+                f"Unsupported MCP source type: {type(mcp_source).__name__}. "
+                "Expected ClientSession, str (URL), or dict (stdio config)."
+            )
+        
+        # Add all loaded tools to the registry
+        for tool in tools:
             self.add(tool, source="mcp")
+    
+    def _validate_stdio_config(self, config: dict) -> None:
+        """Validate stdio configuration dictionary."""
+        if 'command' not in config:
+            raise ValueError("MCP stdio configuration must include 'command'")
+        
+        if not isinstance(config['command'], str):
+            raise TypeError("'command' must be a string")
+        
+        if 'args' in config and not isinstance(config['args'], list):
+            raise TypeError("'args' must be a list of strings")
+        
+        if 'env' in config and not isinstance(config['env'], dict):
+            raise TypeError("'env' must be a dictionary")
 
     def remove(self, name: str) -> bool:
         """


### PR DESCRIPTION
## Summary
- rework MCP utilities to use the official client session
- update Toolkit to accept a ClientSession when loading MCP tools
- simplify MCP tool test using a fake async session

## Testing
- `pytest -q -o addopts=""` *(fails: ImportError: cannot import name 'TypeAdapter' from 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6847457bca10832fa636d83aa38283a1