### PR TITLE
Add optional reranker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ toolkit.add_tools(multiply_numbers, subtract_numbers)
 # Generate schemas for all tools
 tool_schemas = toolkit.tool_schemas()
 
+# With a reranker, filter schemas based on a query
+from vaul.rerankers import CohereReranker
+toolkit_rerank = Toolkit(reranker=CohereReranker(api_key="YOUR_KEY"))
+toolkit_rerank.add_tools(multiply_numbers, subtract_numbers)
+filtered = toolkit_rerank.tool_schemas(
+    messages="multiply two numbers", top_n=1, score_threshold=0.6
+)
+
+# Only tools meeting the score threshold are returned
+
 # Execute a specific tool by name
 result = toolkit.run_tool("add_numbers", {"a": 5, "b": 3})
 print(result)  # Output: 8

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -1,0 +1,39 @@
+from vaul import Toolkit, tool_call
+from vaul.rerankers import BaseReranker, RerankResult
+from tests.utils.assertion import is_equal
+
+
+class MockReranker(BaseReranker):
+    def rerank(self, query, documents, top_n=3):
+        ranked = []
+        for i, doc in enumerate(documents):
+            score = 1.0 if "multiply" in doc.lower() else 0.4
+            ranked.append((score, i))
+        ranked.sort(key=lambda x: x[0], reverse=True)
+        ranked = ranked[:top_n]
+        return [RerankResult(index=i, relevance_score=s) for s, i in ranked]
+
+
+@tool_call
+def add_numbers(a: int, b: int) -> int:
+    """Add two numbers."""
+    return a + b
+
+
+@tool_call
+def multiply_numbers(a: int, b: int) -> int:
+    """Multiply two numbers."""
+    return a * b
+
+
+def test_tool_schemas_with_reranker():
+    toolkit = Toolkit(reranker=MockReranker())
+    toolkit.add_tools(add_numbers, multiply_numbers)
+
+    filtered = toolkit.tool_schemas(
+        messages=[{"role": "user", "content": "How to multiply?"}],
+        top_n=2,
+        score_threshold=0.5,
+    )
+    is_equal(len(filtered), 1)
+    is_equal(filtered[0]["function"]["name"], "multiply_numbers")

--- a/vaul/__init__.py
+++ b/vaul/__init__.py
@@ -2,6 +2,7 @@ from .decorators import tool_call, StructuredOutput
 from .registry import Toolkit
 from .openapi import tools_from_openapi
 from .mcp import tools_from_mcp, tools_from_mcp_url, tools_from_mcp_stdio
+from .rerankers import BaseReranker, CohereReranker
 
 __all__ = [
     "tool_call",
@@ -11,4 +12,6 @@ __all__ = [
     "tools_from_mcp",
     "tools_from_mcp_url",
     "tools_from_mcp_stdio",
+    "BaseReranker",
+    "CohereReranker",
 ]

--- a/vaul/rerankers/__init__.py
+++ b/vaul/rerankers/__init__.py
@@ -1,0 +1,4 @@
+from .base import BaseReranker, RerankResult
+from .cohere import CohereReranker
+
+__all__ = ["BaseReranker", "RerankResult", "CohereReranker"]

--- a/vaul/rerankers/base.py
+++ b/vaul/rerankers/base.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class RerankResult:
+    """Result of a rerank operation."""
+
+    index: int
+    relevance_score: float
+
+
+class BaseReranker:
+    """Base interface for reranking tools."""
+
+    def rerank(self, query: str, documents: List[str], top_n: int = 3) -> List[RerankResult]:
+        """Rerank documents based on their relevance to the query."""
+        raise NotImplementedError

--- a/vaul/rerankers/cohere.py
+++ b/vaul/rerankers/cohere.py
@@ -1,0 +1,19 @@
+from .base import BaseReranker, RerankResult
+from typing import List
+
+
+class CohereReranker(BaseReranker):
+    """Cohere based implementation for reranking."""
+
+    def __init__(self, api_key: str, model: str = "rerank-v3.5"):
+        try:
+            from cohere import Client
+        except Exception as e:  # pragma: no cover - cohere may not be installed
+            raise ImportError("cohere package is required for CohereReranker") from e
+
+        self.client = Client(api_key)
+        self.model = model
+
+    def rerank(self, query: str, documents: List[str], top_n: int = 3) -> List[RerankResult]:
+        response = self.client.rerank(model=self.model, query=query, documents=documents, top_n=top_n)
+        return [RerankResult(index=r.index, relevance_score=r.relevance_score) for r in response.results]


### PR DESCRIPTION
## Summary
- introduce a reranker package with `base.py` and `cohere.py`
- allow `Toolkit.tool_schemas` to filter results by score threshold
- document reranker usage with the new score option
- adjust tests for updated interface

## Testing
- `python -m py_compile vaul/rerankers/base.py vaul/rerankers/cohere.py vaul/rerankers/__init__.py vaul/registry.py tests/test_reranker.py`
- `pytest -q -o addopts=''` *(fails: ImportError: cannot import name 'TypeAdapter' from 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6848368fdf60832f8c186845c75bb156