### PR TITLE
Fix sed command to update version in setup.py

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Update version in setup.py
         run: |
-          sed -i "s/version=['\"][0-9.]\+['\"]/version='${PACKAGE_VERSION}'/" setup.py
+          sed -i "s/version=['\"][0-9]\+\(\.[0-9]\+\)*['\"]/version='${PACKAGE_VERSION}'/" setup.py
           echo "Updated setup.py to version $PACKAGE_VERSION"
 
       - name: Commit and push version bump


### PR DESCRIPTION
This pull request makes a minor update to the version replacement logic in the deployment workflow. The change improves how the version string is matched in `setup.py` to ensure the correct format is used.